### PR TITLE
Corrigiendo nombres

### DIFF
--- a/EFUCVtesis.cls
+++ b/EFUCVtesis.cls
@@ -24,7 +24,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %preámbulo estándar
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{EFUCVtesis2}[01/01/2016 Escuela de Fisica UCV Tesis Versión 1.01]
+\ProvidesClass{EFUCVtesis}[01/01/2016 Escuela de Fisica UCV Tesis Versión 1.01]
 
 %% Article options
 \DeclareOption{12pt}{

--- a/EFUCVtesis.cls
+++ b/EFUCVtesis.cls
@@ -200,6 +200,7 @@
 %% versión 0.5 da error en el veredicto
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \newcommand{\textoportada}[3]{
+\leading{16pt}
 \begin{tabular}{cc} 
 	\rule{#1}{0ex} \rule{0cm}{#2} & \rule{#3}{0ex} \\ 
 	\rule{0pt}{20ex}  &
@@ -235,6 +236,7 @@
 	\rule{0pt}{3ex} &
 	Caracas-Venezuela\\ 
 \end{tabular}
+\leading{18pt}
 }
 
 

--- a/EFUCVtesis.cls
+++ b/EFUCVtesis.cls
@@ -247,7 +247,7 @@
 %%Espaciado entre lineas
 %%%%%%%%%%%%%%%%%%%%%%%%
 \RequirePackage{leading}
-\leading{16pt}
+\leading{18pt}
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%
 %%encabezado y pie de pagina

--- a/EFUCVtesis/carta_tutor.tex
+++ b/EFUCVtesis/carta_tutor.tex
@@ -20,7 +20,7 @@ Reciban un cordial saludo. Conforme a lo establecido en el art铆culo 13 de la 鈥
    		{{del}}
    		{\ifthenelse{\equal{\tesisautorgen}{f}}
    		{{de la}}
-   		{{\bf Error! designaci贸n de genero de autor no admitida. Use letras min煤culas m o f}}} estudiante {\bf \tesisautor}, CI: {\bf \tesisautorcedula}, titulado \tesistitulo{}, los cuales \ifthenelse{\equal{\Dtutores}{si}}
+   		{{\bf Error! designaci贸n de genero de autor no admitida. Use letras min煤culas m o f}}} estudiante {\bf \tesisautor}, CI: {\bf \tesisautorcedula}, titulado {\bf \tesistitulo{}}, los cuales \ifthenelse{\equal{\Dtutores}{si}}
 {hemos revisado y consideramos}{he revisado y considero} listos para la evaluaci贸n por parte de un jurado.
 
 Agradeciendo la consideraci贸n que sirvan prestar a la presente, \ifthenelse{\equal{\Dtutores}{si}}

--- a/LEEME
+++ b/LEEME
@@ -1,4 +1,4 @@
-Instrucciones para uso del cls EFUCVtesis2.cls
+Instrucciones para uso del cls EFUCVtesis.cls
 
 Los archivos para comenzar son mi_tesis.tex y bibliografia.bib
 
@@ -9,8 +9,8 @@ mi_tesis.tex es un documento modelo. En los comentarios encontrará este mensaje
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 % Este ejemplo ha sido elaborado por Jose Antonio López. Dudas: jal.ccs@gmail.com
-% Está basado en el cls EFUCVtesis2.cls
-% EFUCVtesis2 ajusta los márgenes del documento, define babel spanish y fuentes utf8, que permiten usar 
+% Está basado en el cls EFUCVtesis.cls
+% EFUCVtesis ajusta los márgenes del documento, define babel spanish y fuentes utf8, que permiten usar 
 % acentos. También define funciones para manejar la información del autor, título, tutores e 
 % incluye las portadas. Los comentarios dan instrucciones sobre el uso de dichas funciones
 %%
@@ -49,13 +49,13 @@ IMPORTANTE
 
 ###########################################
 
-EFUCVtesis2.cls Versión 1.0 está basado en book.cls. La ejecución requiere imágenes y archivos que están almacenados en la carpeta llamada EFUCVtesis. Ésta carpeta no debe borrarse. 
+EFUCVtesis.cls Versión 1.01 está basado en book.cls. La ejecución requiere imágenes y archivos que están almacenados en la carpeta llamada EFUCVtesis. Ésta carpeta no debe borrarse. 
 
-Ud no debe editar el documento EFUCVtesis2.cls, ni los archivos dentro de la carpeta EFUCVtesis, a menos que sepa muy bien lo que está haciendo. 
+Ud no debe editar el documento EFUCVtesis.cls, ni los archivos dentro de la carpeta EFUCVtesis, a menos que sepa muy bien lo que está haciendo. 
 Por cierto, aún cuando sepa lo que está haciendo, no se recomienda editar ninguno de estos documentos.
 
 #################################
-Paquetes requeridos por EFUCVtesis2
+Paquetes requeridos por EFUCVtesis
 ##################################
 
 inputenc [utf8] <- escritura normal en español (acentos y eñes)
@@ -75,7 +75,7 @@ IMPORTANTE (usuarios debian y derivados)
 
 ###########################################
 
-Es altamente recomdendable tomarse la molestia de actualizar TexLive antes de trabajar con EFUCVtesis2.cls 
+Es altamente recomdendable tomarse la molestia de actualizar TexLive antes de trabajar con EFUCVtesis.cls 
 1.
 	$sudo add-apt-repository ppa:texlive-backports/ppa
 2.

--- a/mi_tesis.tex
+++ b/mi_tesis.tex
@@ -3,7 +3,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 % Este ejemplo ha sido elaborado por Jose Antonio López. Dudas: jal.ccs@gmail.com
-% Está basado en el cls EFUCVtesis2.cls
+% Está basado en el cls EFUCVtesis.cls
 % EFUCVtesis2 ajusta los márgenes del documento, define babel spanish y fuentes utf8, que permiten usar 
 % acentos. También define funciones para manejar la información del autor, título, tutores e 
 % incluye las portadas. Los comentarios dan instrucciones sobre el uso de dichas funciones
@@ -26,7 +26,7 @@
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\documentclass{EFUCVtesis2} % importa el cls con los estilos para los TEG de la EF de la UCV
+\documentclass{EFUCVtesis} % importa el cls con los estilos para los TEG de la EF de la UCV
 %
 %
 \titulo{Estudio del Superconductor Intermetálico ternario \NoCaseChange{\ce{La3Pd4Si4}} mediante la dependencia con la temperatura de la longitud de penetración magnética en dimensión \NoCaseChange{$\mathbf{d=3+1}$}}

--- a/mi_tesis/nombrecapitulodos.tex
+++ b/mi_tesis/nombrecapitulodos.tex
@@ -44,7 +44,7 @@ Integer ut dapibus justo, id dictum erat. Nulla facilisi. Aliquam rhoncus mi feu
 \item Los TEG se imprimen a doble cara 
 \item Los márgenes superior e inferior son de 2,5 cm entre el papel y el texto 
 \item En las páginas pares (izquierdas) el margen derecho es de 3 cm, el izquierdo es de 2,5 cm
-\item La separaci\'on entre l\'ineas es de 16pt 
+\item La separaci\'on entre l\'ineas es de 18pt 
 \item En las páginas impares (derechas) las dimensiones de los márgenes se invierten.
 \item Los headers y footers son opcionales. En caso de usarse, las páginas izquierdas muestran el nombre del capítulo. Las derechas muestran el nombre de la sección.
 \item Las páginas se numeran en la parte superior-exterior del libro (lado izquierdo en páginas pares y lado derecho en páginas impares)

--- a/mi_tesis/nombrecapitulouno.tex
+++ b/mi_tesis/nombrecapitulouno.tex
@@ -43,7 +43,7 @@ Duis ac purus arcu. Nam posuere, neque eu elementum pretium, nulla ligula faucib
 \item Los TEG se imprimen a doble cara 
 \item Los márgenes superior e inferior son de 2,5 cm entre el papel y el texto 
 \item En las páginas pares (izquierdas) el margen derecho es de 3 cm, el izquierdo es de 2,5 cm
-\item La separaci\'on entre l\'ineas es de 16pt  
+\item La separaci\'on entre l\'ineas es de 18pt  
 \item En las páginas impares (derechas) las dimensiones de los márgenes se invierten.
 \item Los headers y footers son opcionales. En caso de usarse, las páginas izquierdas muestran el nombre del capítulo. Las derechas muestran el nombre de la sección.
 \item Las páginas se numeran en la parte superior-exterior del libro (lado izquierdo en páginas pares y lado derecho en páginas impares)

--- a/mi_tesis/portadaconmedidas.tex
+++ b/mi_tesis/portadaconmedidas.tex
@@ -16,6 +16,7 @@
 \cleardoublepage
 \thispagestyle{empty}
 \AddToShipoutPicture*{\BackgroundPic}
+\leading{16pt}
 \begin{tabular}{cc} 
 	\rule{0.67cm}{0ex} \rule{0cm}{3ex} & \rule{16.25cm}{0ex} \\ 
 	\rule{5pt}{20ex} 3 cm  &
@@ -27,8 +28,7 @@
 	\rule{5pt}{10ex}} 1,5 cm\\ 
 	\rule{5pt}{24ex} 3,6 cm & 
 	\includegraphics[scale=1]{logoucvgifpeq.png}\\ 	\rule{5pt}{26ex} 3,9 cm &
-		\raisebox{10ex}{\parbox[c]{15cm}{ \centering \tesistitulo }} \\ 
-		%\raisebox{10ex}{\parbox[c]{15cm}{\sc \centering {\tesistitulo}}} \\ 
+		\raisebox{10ex}{\parbox[c]{15cm}{ \centering {\bfseries \MakeTextUppercase{\expandafter{\tesistitulo}}} }} \\ 
 	\rule{5pt}{19ex} 2,9 cm &
 	\parbox[c]{8cm}{			
 		\centering
@@ -52,3 +52,4 @@
 	\rule{5pt}{3ex} 0,5 cm &
 	Caracas-Venezuela\\ 
 \end{tabular}
+\leading{18pt}

--- a/mi_tesis/portadaconmedidas.tex
+++ b/mi_tesis/portadaconmedidas.tex
@@ -3,7 +3,7 @@
 \item Los TEG se imprimen a doble cara 
 \item Los márgenes superior e inferior son de 2,5 cm entre el papel y el texto 
 \item En las páginas pares (izquierdas) el margen derecho es de 3 cm, el izquierdo es de 2,5 cm
-\item La separaci\'on entre l\'ineas es de 16pt 
+\item La separaci\'on entre l\'ineas es de 18pt 
 \item En las páginas impares (derechas) las dimensiones de los márgenes se invierten.
 \item Los headers y footers son opcionales. En caso de usarse, las páginas izquierdas muestran el nombre del capítulo. Las derechas muestran el nombre de la sección.
 \item Las páginas se numeran en la parte superior-exterior del libro (lado izquierdo en páginas pares y lado derecho en páginas impares)


### PR DESCRIPTION
Se cambió el nombre del .cls de EFUCVtesis2.cls a EFUCVtesis.cls

Aprovechamos para aumentar el espacio del interlineado de 16pt a 18pt

Se detectó un error en la portada con medidas, no se colocaba el título en mayúsculas.

El interlineado de la portada debe quedar en 16pt. Se ajustó.

En la carta de culminación (aparece en lugar del veredicto) se cambió el título del TEG a negritas.
